### PR TITLE
feat: 添加 CHECK_UA 和 TEMPLATE_URL 环境变量支持

### DIFF
--- a/src/core/mihomo/index.js
+++ b/src/core/mihomo/index.js
@@ -5,7 +5,7 @@ import clashConfig from '../../config/mihomo.js';
 export async function getmihomo_config(e) {
     const config = structuredClone(clashConfig);
     // 客户端验证
-    if (!/meta|clash.meta|clash|clashverge|mihomo/i.test(e.userAgent)) {
+    if (e.checkUA && !/meta|clash.meta|clash|clashverge|mihomo/i.test(e.userAgent)) {
         throw new Error('不支持的客户端');
     }
     if (!e.rule) {

--- a/src/core/singbox/index.js
+++ b/src/core/singbox/index.js
@@ -46,7 +46,7 @@ export async function getsingbox_config(e) {
 export function Verbose(e) {
     const ua = e.userAgent;
 
-    if (!/singbox|sing-box|sfa|sfm/i.test(ua)) {
+    if (e.checkUA && !/singbox|sing-box|sfa|sfm/i.test(ua)) {
         throw new Error('不支持的客户端');
     }
 

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -49,9 +49,14 @@ export function buildConfig(request, env, isNode = false) {
     data.beian = getEnv('BEIAN', beiantext);
     data.beianurl = getEnv('BEIANURL', beiandizi);
 
+    const templateBaseUrl = getEnv('TEMPLATE_URL', '');
     const template = getParam('template');
     if (template) {
-        data.rule = `${url.origin}${isNode ? '/template' : ''}/${data.target}${getParam('template') ? getParam('template') : ''}`;
+        if (templateBaseUrl) {
+            data.rule = `${templateBaseUrl}/${data.target}${template}`;
+        } else {
+            data.rule = `${url.origin}${isNode ? '/template' : ''}/${data.target}${template}`;
+        }
     }
 
     return data;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,14 @@ name = "cf-worker-mihomo"
 main = "dist/_worker.js"
 compatibility_date = "2025-04-16"
 compatibility_flags = ["nodejs_compat"]
+
+[vars]
+BEIAN = ""
+BEIANURL = ""
+SUB = ""
+CHECK_UA = "true"
+TEMPLATE_URL = ""
+
 [assets]
 directory = "./template"
 binding = "ASSETS"


### PR DESCRIPTION
## 改动说明

### 1. CHECK_UA 环境变量

新增 `CHECK_UA` 环境变量，控制是否校验客户端 User-Agent。

- 默认值：`true`（保持原有行为，校验 UA）
- 设为 `false` 时跳过 UA 校验，允许浏览器等非代理客户端直接访问订阅链接

适用于需要在浏览器中调试或分享订阅链接的场景。

### 2. TEMPLATE_URL 环境变量

新增 `TEMPLATE_URL` 环境变量，支持从外部 URL 获取规则模板。

- 默认值：空（保持原有行为，从 Worker 自身域名获取）
- 设置后（如 GitHub Raw 地址），模板从指定 URL 获取

**背景**：CF Workers 中 Worker 内部 `fetch()` 请求自身域名会经过 Worker 的 fetch handler，而非 assets 路由。设置外部 `TEMPLATE_URL` 可规避此问题。

### 改动文件

| 文件 | 改动 |
|------|------|
| `src/utils/env.js` | 新增 `CHECK_UA`、`TEMPLATE_URL` 解析 |
| `src/core/mihomo/index.js` | UA 校验加 `e.checkUA` 前置条件 |
| `src/core/singbox/index.js` | UA 校验加 `e.checkUA` 前置条件 |