### PR TITLE
feat: support external templates.json via TEMPLATE_URL

### DIFF
--- a/src/core/page/page.js
+++ b/src/core/page/page.js
@@ -1,6 +1,21 @@
 import configs from './config.js';
 
 export async function getFakePage(e) {
+    let configData = JSON.parse(configs());
+    if (e.templateBaseUrl) {
+        try {
+            const res = await fetch(`${e.templateBaseUrl}/templates.json`);
+            if (res.ok) {
+                const externalTemplates = await res.json();
+                for (const [target, templates] of Object.entries(externalTemplates)) {
+                    if (configData[target]) {
+                        configData[target].templates = templates;
+                    }
+                }
+            }
+        } catch (_) {}
+    }
+    const configJson = JSON.stringify(configData);
     return `
 <!DOCTYPE html>
 <html lang="zh-CN">
@@ -546,7 +561,7 @@ export async function getFakePage(e) {
     </a>
 
     <script>
-        const MODES_META = ${configs()};
+        const MODES_META = ${configJson};
 
         let currentMode = 'mihomo';
 

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -50,6 +50,7 @@ export function buildConfig(request, env, isNode = false) {
     data.beianurl = getEnv('BEIANURL', beiandizi);
 
     const templateBaseUrl = getEnv('TEMPLATE_URL', '');
+    if (templateBaseUrl) data.templateBaseUrl = templateBaseUrl;
     const template = getParam('template');
     if (template) {
         if (templateBaseUrl) {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,13 +4,6 @@ main = "dist/_worker.js"
 compatibility_date = "2025-04-16"
 compatibility_flags = ["nodejs_compat"]
 
-[vars]
-BEIAN = ""
-BEIANURL = ""
-SUB = ""
-CHECK_UA = "true"
-TEMPLATE_URL = ""
-
 [assets]
 directory = "./template"
 binding = "ASSETS"


### PR DESCRIPTION
## Changes

- **外部模板列表加载**: 当 `TEMPLATE_URL` 环境变量有值时，Web UI 从 `${TEMPLATE_URL}/templates.json` 加载模板列表，替代内置的硬编码模板
- **暴露 templateBaseUrl**: `env.js` 中将 `TEMPLATE_URL` 存入 `data.templateBaseUrl` 供 `page.js` 使用
- **移除 wrangler.toml [vars]**: 环境变量改用 `wrangler secret` 管理，本地开发用 `.dev.vars`

## Files Changed

| File | Change |
|------|--------|
| `src/core/page/page.js` | 新增外部 templates.json 获取逻辑，覆盖默认模板 |
| `src/utils/env.js` | 暴露 `templateBaseUrl` 到 data 对象 |
| `wrangler.toml` | 移除 `[vars]` 部分，环境变量通过 secret 管理 |