### PR TITLE
feat: mihomo proxy-provider mode (pp)

### DIFF
--- a/src/core/mihomo/index.js
+++ b/src/core/mihomo/index.js
@@ -11,6 +11,9 @@ export async function getmihomo_config(e) {
     if (!e.rule) {
         throw new Error('缺少规则模板');
     }
+    if (e.proxyprovider) {
+        return await getmihomo_config_provider(e, config);
+    }
     const alldata = await Promise.all([
         getProxies_Data(e),
         fetchResponse(e.rule),
@@ -40,6 +43,59 @@ export async function getmihomo_config(e) {
     return {
         status: Proxies_Data.status,
         headers: Proxies_Data.headers,
+        data: JSON.stringify(config, null, 4),
+    };
+}
+
+/**
+ * Proxy-Provider 模式：不下载订阅，由客户端直接拉取
+ * 订阅 URL 作为 proxy-provider 注入，模板中的 filter 由 mihomo 客户端原生过滤
+ */
+async function getmihomo_config_provider(e, config) {
+    const alldata = await Promise.all([
+        fetchResponse(e.rule),
+        e.exclude_package ? fetchpackExtract() : null,
+        e.exclude_address ? fetchipExtract() : null,
+    ]);
+    const Rule_Data = alldata[0];
+    if (!Rule_Data?.data) {
+        throw new Error('获取规则数据失败');
+    }
+    e.Package = alldata[1];
+    e.Address = alldata[2];
+
+    // 从订阅 URL 创建 proxy-providers
+    const providers = {};
+    if (e.urls?.httpUrls) {
+        e.urls.httpUrls.forEach((url, i) => {
+            providers[`sub-${i}`] = {
+                type: 'http',
+                url,
+                interval: 3600,
+                path: `./proxies/sub-${i}.yaml`,
+                'health-check': {
+                    enable: true,
+                    url: 'https://www.gstatic.com/generate_204',
+                    interval: 300,
+                },
+            };
+        });
+    }
+
+    // 为有 filter 的策略组添加 include-all，使 mihomo 客户端原生过滤
+    if (Rule_Data.data['proxy-groups']) {
+        for (const group of Rule_Data.data['proxy-groups']) {
+            if (group.filter && !group['include-all']) {
+                group['include-all'] = true;
+            }
+        }
+    }
+
+    Rule_Data.data['proxy-providers'] = providers;
+    applyTemplate(config, Rule_Data.data, e);
+    return {
+        status: 200,
+        headers: {},
         data: JSON.stringify(config, null, 4),
     };
 }

--- a/src/core/page/config.js
+++ b/src/core/page/config.js
@@ -26,12 +26,15 @@ export default function configs() {
 ✔ 仅代理: 关闭tun，纯http/socks代理
 
 ✔ fallback: 获取原节点格式和流量信息
+
+✔ Proxy-Provider: 不下载订阅，由客户端直接拉取订阅链接（仅 mihomo）
             `,
-            protocolList: ['udp', 'ech', 'relay', 'ep', 'ea', 'adgdns', 'tun', 'fallback', 'log'],
+            protocolList: ['udp', 'ech', 'relay', 'pp', 'ep', 'ea', 'adgdns', 'tun', 'fallback', 'log'],
             protocolLabels: {
                 udp: 'UDP',
                 ech: 'ECH',
                 relay: '链式代理',
+                pp: 'Proxy-Provider',
                 ep: '分应用代理',
                 ea: '分IPCIDR代理',
                 adgdns: '去广告DNS',

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -43,6 +43,7 @@ export function buildConfig(request, env, isNode = false) {
     if (getParamBool('ech')) data.ech = true;
     if (getParamBool('relay')) data.relay = true;
     if (getParamBool('fallback')) data.fallback = true;
+    if (getParamBool('pp')) data.proxyprovider = true;
 
     data.IMG = getEnv('IMG', backimg);
     data.sub = getEnv('SUB', subapi);


### PR DESCRIPTION
## Changes

新增 `pp=true` URL 参数，启用 mihomo 的 Proxy-Provider 模式。

### 行为差异

| | 默认模式 | Proxy-Provider 模式 (`pp=true`) |
|---|---------|------|
| 订阅下载 | Worker 下载并解析 | **不下载**，客户端自行拉取 |
| 节点过滤 | 服务端正则匹配 | mihomo 客户端原生 `filter` |
| 配置体积 | 全部内联 | 仅 proxy-provider URL |

### 工作原理

1. 订阅 URL 作为 `proxy-providers` 注入配置（`sub-0`, `sub-1`, ...）
2. 模板中有 `filter` 的策略组自动添加 `include-all: true`
3. mihomo 客户端拉取订阅后使用 `filter` 原生过滤国家分组
4. 其他功能（tun、adgdns、exclude 等）不受影响

### Files Changed

| File | Change |
|------|--------|
| `src/utils/env.js` | 新增 `pp` bool 参数 → `data.proxyprovider` |
| `src/core/page/config.js` | mihomo 附加参数增加 Proxy-Provider 选项 |
| `src/core/mihomo/index.js` | 新增 `getmihomo_config_provider()` 函数 |